### PR TITLE
feat: add default tool config option (claude-code or copilot)

### DIFF
--- a/console/config.default.toml
+++ b/console/config.default.toml
@@ -21,5 +21,7 @@ user_callsign = "Dispatch"
 console_name = "Console"
 
 [tools]
+# Which tool to use by default when dispatching agents: "claude-code" or "copilot".
+default = "claude-code"
 claude-code = "claude"
 copilot = "gh copilot suggest"

--- a/console/src/app.rs
+++ b/console/src/app.rs
@@ -21,6 +21,7 @@ impl App {
         pane_rows: u16,
         pane_cols: u16,
         tools: std::collections::HashMap<String, String>,
+        default_tool: String,
         workspace: Workspace,
         scrollback_lines: u32,
         chat_tx: tokio::sync::broadcast::Sender<String>,
@@ -46,6 +47,7 @@ impl App {
             pane_rows,
             pane_cols,
             tools,
+            default_tool,
             ticker_items: Vec::new(),
             ticker_frame_counter: 0,
             workspace,
@@ -317,9 +319,10 @@ impl App {
 
                 // Spawn PTY if slot is empty. Agent creates its own worktree.
                 if self.slots[slot_idx].is_none() {
-                    let cmd = self.tool_cmd("claude-code").to_string();
+                    let tool_key = self.default_tool.clone();
+                    let cmd = self.tool_cmd(&tool_key).to_string();
                     match dispatch_slot(
-                        slot_idx, "claude-code", &cmd, self.pane_rows, self.pane_cols,
+                        slot_idx, &tool_key, &cmd, self.pane_rows, self.pane_cols,
                         None, self.scrollback_lines,
                         repo_name_from_path(&target_repo), &target_repo,
                         Some(&full_prompt),
@@ -348,7 +351,7 @@ impl App {
                 };
 
                 self.push_orch(OrchestratorEventKind::Dispatched {
-                    agent: callsign.clone(), slot: slot_idx + 1, tool: "claude-code".to_string(),
+                    agent: callsign.clone(), slot: slot_idx + 1, tool: self.default_tool.clone(),
                 });
                 self.push_ticker(format!(
                     "DISPATCH: {} (slot {})", callsign, slot_idx + 1
@@ -360,7 +363,7 @@ impl App {
                     let mut st = self.ws_state.lock().unwrap();
                     st.slots[slot_idx] = Some(ws_server::AgentSlot {
                         callsign: callsign.clone(),
-                        tool: "claude-code".to_string(),
+                        tool: self.default_tool.clone(),
                         status: ws_server::AgentStatus::Busy,
                         task: None,
                         repo: Some(repo_name_from_path(&target_repo).to_string()),

--- a/console/src/config.rs
+++ b/console/src/config.rs
@@ -68,6 +68,15 @@ fn default_identity() -> IdentityConfig {
 }
 
 impl Config {
+    /// Returns the configured default tool key (e.g. "claude-code" or "copilot").
+    /// Falls back to "claude-code" if not set.
+    pub fn default_tool_key(&self) -> &str {
+        self.tools
+            .get("default")
+            .map(|s| s.as_str())
+            .unwrap_or("claude-code")
+    }
+
     /// Effective callsign list. Uses [agents].callsigns if present,
     /// otherwise generates NATO names from terminal.max_agents for
     /// backward compatibility.
@@ -92,6 +101,7 @@ impl Default for Config {
     fn default() -> Self {
         let psk = generate_psk();
         let mut tools = HashMap::new();
+        tools.insert("default".to_string(), "claude-code".to_string());
         tools.insert("claude-code".to_string(), "claude".to_string());
         tools.insert("copilot".to_string(), "gh copilot suggest".to_string());
 
@@ -218,14 +228,18 @@ pub fn load_or_create_tls() -> TlsIdentity {
 fn to_toml_with_comments(cfg: &Config) -> String {
     // Build tools table manually for consistent ordering.
     let mut tools_lines = String::new();
-    // Ensure canonical ordering.
+    // Default tool selection first.
+    let default_tool = cfg.default_tool_key();
+    tools_lines.push_str(&format!("# Which tool to use by default when dispatching agents: \"claude-code\" or \"copilot\".\n"));
+    tools_lines.push_str(&format!("default = \"{default_tool}\"\n"));
+    // Ensure canonical ordering for tool commands.
     for key in ["claude-code", "copilot"] {
         if let Some(val) = cfg.tools.get(key) {
             tools_lines.push_str(&format!("{key} = \"{val}\"\n"));
         }
     }
     for (k, v) in &cfg.tools {
-        if k != "claude-code" && k != "copilot" {
+        if k != "claude-code" && k != "copilot" && k != "default" {
             tools_lines.push_str(&format!("{k} = \"{v}\"\n"));
         }
     }

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -167,6 +167,7 @@ fn main() -> io::Result<()> {
         pane_rows,
         pane_cols,
         cfg.tools.clone(),
+        cfg.default_tool_key().to_string(),
         workspace,
         cfg.terminal.scrollback_lines,
         chat_tx,
@@ -653,10 +654,11 @@ fn main() -> io::Result<()> {
                                             app.overlay = Overlay::None;
                                             // Dispatch into the first empty slot, targeting the selected repo.
                                             if let Some(g) = app.slots.iter().position(|s| s.is_none()) {
-                                                let cmd = app.tool_cmd("claude-code").to_string();
+                                                let tool_key = app.default_tool.clone();
+                                                let cmd = app.tool_cmd(&tool_key).to_string();
                                                 let cs = app.next_callsign().unwrap_or_else(|| format!("Agent-{}", g + 1));
                                                 if let Some(slot) = pty::dispatch_slot(
-                                                    g, "claude-code", &cmd, app.pane_rows, app.pane_cols,
+                                                    g, &tool_key, &cmd, app.pane_rows, app.pane_cols,
                                                     Some(&selected_repo), app.scrollback_lines,
                                                     util::repo_name_from_path(&selected_repo), &selected_repo,
                                                     None,
@@ -665,7 +667,7 @@ fn main() -> io::Result<()> {
                                                     let page = g / SLOTS_PER_PAGE;
                                                     let local = g % SLOTS_PER_PAGE;
                                                     let name = slot.display_name().to_string();
-                                                    app.push_orch(OrchestratorEventKind::Dispatched { agent: name.clone(), slot: g + 1, tool: "claude-code".to_string() });
+                                                    app.push_orch(OrchestratorEventKind::Dispatched { agent: name.clone(), slot: g + 1, tool: tool_key });
                                                     app.push_ticker(format!("DISPATCH: {} launched in slot {} — repo {}", name, g + 1, util::repo_name_from_path(&selected_repo)));
                                                     app.push_chat("System", &format!("Dispatched agent {} to slot {}.", name, g + 1));
                                                     app.slots[g] = Some(slot);
@@ -751,16 +753,17 @@ fn main() -> io::Result<()> {
                                     if app.slots[target_g].is_none() {
                                         let cs = app.next_callsign().unwrap_or_else(|| format!("Agent-{}", target_g + 1));
                                         let repo = app.default_repo_root().to_string();
-                                        let cmd = app.tool_cmd("claude-code").to_string();
+                                        let tool_key = app.default_tool.clone();
+                                        let cmd = app.tool_cmd(&tool_key).to_string();
                                         if let Some(slot) = pty::dispatch_slot(
-                                            target_g, "claude-code", &cmd, app.pane_rows, app.pane_cols,
+                                            target_g, &tool_key, &cmd, app.pane_rows, app.pane_cols,
                                             None, app.scrollback_lines,
                                             util::repo_name_from_path(&repo), &repo,
                                             None,
                                             &cs,
                                         ) {
                                             let name = slot.display_name().to_string();
-                                            app.push_orch(OrchestratorEventKind::Dispatched { agent: name.clone(), slot: target_g + 1, tool: "claude-code".to_string() });
+                                            app.push_orch(OrchestratorEventKind::Dispatched { agent: name.clone(), slot: target_g + 1, tool: tool_key.clone() });
                                             app.push_ticker(format!("DISPATCH: {} launched in slot {}", name, target_g + 1));
                                             app.push_chat("System", &format!("Dispatched agent {} to slot {}.", name, target_g + 1));
                                             app.slots[target_g] = Some(slot);
@@ -769,7 +772,7 @@ fn main() -> io::Result<()> {
                                                 let mut st = app.ws_state.lock().unwrap();
                                                 st.slots[target_g] = Some(ws_server::AgentSlot {
                                                     callsign: name.clone(),
-                                                    tool: "claude-code".to_string(),
+                                                    tool: tool_key,
                                                     status: ws_server::AgentStatus::Idle,
                                                     task: None,
                                                     repo: Some(util::repo_name_from_path(&repo).to_string()),

--- a/console/src/types.rs
+++ b/console/src/types.rs
@@ -150,6 +150,8 @@ pub struct App {
     pub pane_rows: u16,
     pub pane_cols: u16,
     pub tools: std::collections::HashMap<String, String>,
+    /// Which tool key to use by default when dispatching agents (e.g. "claude-code" or "copilot").
+    pub default_tool: String,
     // Ticker: LED-style scrolling marquee (independent items)
     pub ticker_items: Vec<TickerItem>,
     pub ticker_frame_counter: u8,


### PR DESCRIPTION
Adds a `default` key to the `[tools]` section in `config.toml` that controls which coding tool is used when dispatching agents.

## Changes

- **config.default.toml**: Added `default = "claude-code"` with a comment explaining the option
- **config.rs**: Added `default_tool_key()` helper method on `Config`; updated `Config::default()` and `to_toml_with_comments()` to include the new key
- **types.rs**: Added `default_tool: String` field to `App` struct
- **app.rs**: Updated `App::new()` to accept `default_tool`; replaced hardcoded `"claude-code"` with the configured default in orchestrator dispatch
- **main.rs**: Passed `cfg.default_tool_key()` to `App::new()`; replaced hardcoded `"claude-code"` with the configured default in repo-select and `n`-key dispatch paths

## Usage

In config.toml:

`	oml
[tools]
default = "claude-code"   # or "copilot"
claude-code = "claude"
copilot = "gh copilot suggest"
`

The default is `"claude-code"`. Existing configs without the `default` key will continue to work unchanged.
