### PR TITLE
fix: gate Claude Code-specific CLI flags on tool_key

### DIFF
--- a/console/core/src/handler.rs
+++ b/console/core/src/handler.rs
@@ -58,6 +58,8 @@ pub struct ConsoleState {
     pub user_callsign: String,
     /// Display name for the console/orchestrator (default: "Console").
     pub console_name: String,
+    /// Default tool key for dispatching agents (e.g. "claude-code" or "copilot").
+    pub default_tool: String,
 }
 
 impl ConsoleState {
@@ -72,6 +74,7 @@ impl ConsoleState {
             event_tx: None,
             user_callsign: "Dispatch".to_string(),
             console_name: "Console".to_string(),
+            default_tool: "claude-code".to_string(),
         }
     }
 
@@ -249,8 +252,8 @@ pub fn handle_message(raw: RawInbound, state: &SharedState) -> Option<OutboundMs
         }
 
         "dispatch" => {
-            let tool = raw.tool.as_deref().unwrap_or("claude-code").to_string();
             let mut st = state.lock().unwrap();
+            let tool = raw.tool.as_deref().unwrap_or(&st.default_tool).to_string();
 
             let slot = if let Some(s) = raw.slot {
                 s

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -114,6 +114,7 @@ fn main() -> io::Result<()> {
         let mut state = ws_server::ConsoleState::new(callsigns.clone());
         state.user_callsign = cfg.identity.user_callsign.clone();
         state.console_name = cfg.identity.console_name.clone();
+        state.default_tool = cfg.default_tool_key().to_string();
         state
     }));
     {

--- a/console/src/pty.rs
+++ b/console/src/pty.rs
@@ -105,21 +105,23 @@ pub fn dispatch_slot(
     // instead of echoing to the terminal. This eliminates terminal noise issues.
     cmd.env("DISPATCH_MSG_FILE", &msg_file);
 
-    // Inject agent instructions from docs/AGENTS.md as system prompt,
-    // with shared memory appended so agents benefit from prior learnings.
-    let agents_md_path = format!("{}/docs/AGENTS.md", repo_root);
-    if let Ok(mut instructions) = std::fs::read_to_string(&agents_md_path) {
-        let memory = read_memory_file(repo_root);
-        let memory = memory.trim();
-        if !memory.is_empty() {
-            instructions.push_str("\n\n---\n\n## Shared Memory (from prior agents)\n\n");
-            instructions.push_str(memory);
-            instructions.push('\n');
+    // Claude Code-specific flags: system prompt injection and permission bypass.
+    // Other tools (e.g. copilot) don't support these flags.
+    if tool_key == "claude-code" {
+        let agents_md_path = format!("{}/docs/AGENTS.md", repo_root);
+        if let Ok(mut instructions) = std::fs::read_to_string(&agents_md_path) {
+            let memory = read_memory_file(repo_root);
+            let memory = memory.trim();
+            if !memory.is_empty() {
+                instructions.push_str("\n\n---\n\n## Shared Memory (from prior agents)\n\n");
+                instructions.push_str(memory);
+                instructions.push('\n');
+            }
+            cmd.arg("--system-prompt");
+            cmd.arg(&instructions);
         }
-        cmd.arg("--system-prompt");
-        cmd.arg(&instructions);
+        cmd.arg("--dangerously-skip-permissions");
     }
-    cmd.arg("--dangerously-skip-permissions");
     if let Some(prompt) = initial_prompt {
         cmd.arg(prompt);
     }


### PR DESCRIPTION
Fixes 'unknown option --system-prompt' error when dispatching agents with a non-Claude tool (e.g. GitHub Copilot).

## Problem

--system-prompt and --dangerously-skip-permissions are Claude Code-specific CLI flags that were unconditionally appended to every agent PTY command in pty.rs. When the configured default tool is copilot, the spawned gh copilot suggest process would fail with an unknown option error.

Additionally, the WebSocket handler (handler.rs) hardcoded claude-code as the fallback tool when radio clients dispatched without specifying a tool, ignoring the configured default.

## Changes

- **pty.rs**: Gate --system-prompt and --dangerously-skip-permissions behind a tool_key == claude-code check so non-Claude tools are spawned without Claude-specific flags
- **handler.rs**: Add default_tool field to ConsoleState; radio dispatch now reads from this field instead of hardcoding claude-code
- **main.rs**: Set default_tool on ConsoleState from the config at startup

## Testing

All 34 workspace tests pass.
