### PR TITLE
fix: advertise console on preferred LAN interface

### DIFF
--- a/console/Cargo.lock
+++ b/console/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "dispatch-core",
  "futures-util",
  "hostname",
+ "if-addrs",
  "mdns-sd",
  "portable-pty",
  "rand",

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -28,6 +28,7 @@ tokio-tungstenite = "0.21"
 futures-util = "0.3"
 mdns-sd = "0.11"
 hostname = "0.4"
+if-addrs = "0.13"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pemfile = "2"

--- a/console/src/mdns.rs
+++ b/console/src/mdns.rs
@@ -3,8 +3,9 @@
 // Advertises the console's WebSocket server as `_dispatch._tcp.local.`
 // so the Android radio can discover it on the LAN without manual IP entry.
 
+use crate::util::preferred_lan_ipv4;
 use mdns_sd::{ServiceDaemon, ServiceInfo};
-use std::collections::HashMap;
+use std::{collections::HashMap, net::IpAddr};
 
 const SERVICE_TYPE: &str = "_dispatch._tcp.local.";
 
@@ -35,15 +36,27 @@ pub fn advertise(port: u16, tls_fingerprint: Option<&str>) -> Option<ServiceDaem
         map
     });
 
-    let service = match ServiceInfo::new(
-        SERVICE_TYPE,
-        &hostname,
-        &host_label,
-        "",   // empty IP = auto-detect all interfaces
-        port,
-        properties,
-    ) {
-        Ok(s) => s.enable_addr_auto(),
+    let advertised_ip = preferred_lan_ipv4();
+    let service = match match advertised_ip {
+        Some(ip) => ServiceInfo::new(
+            SERVICE_TYPE,
+            &hostname,
+            &host_label,
+            IpAddr::V4(ip),
+            port,
+            properties,
+        ),
+        None => ServiceInfo::new(
+            SERVICE_TYPE,
+            &hostname,
+            &host_label,
+            "", // fallback: auto-detect if we could not pick a LAN IPv4
+            port,
+            properties,
+        )
+        .map(|s| s.enable_addr_auto()),
+    } {
+        Ok(s) => s,
         Err(e) => {
             eprintln!("mdns: failed to create service info: {e}");
             return None;
@@ -55,6 +68,10 @@ pub fn advertise(port: u16, tls_fingerprint: Option<&str>) -> Option<ServiceDaem
         return None;
     }
 
-    eprintln!("mdns: advertising {SERVICE_TYPE} on port {port}");
+    if let Some(ip) = advertised_ip {
+        eprintln!("mdns: advertising {SERVICE_TYPE} on {ip}:{port}");
+    } else {
+        eprintln!("mdns: advertising {SERVICE_TYPE} on port {port} (auto interface)");
+    }
     Some(mdns)
 }

--- a/console/src/util.rs
+++ b/console/src/util.rs
@@ -1,6 +1,7 @@
 // Standalone utility functions for the dispatch console.
 
-use std::time::Duration;
+use if_addrs::{get_if_addrs, IfAddr};
+use std::{net::Ipv4Addr, time::Duration};
 use time::macros::format_description;
 
 /// Format local time as "HH:MM:SS". Falls back to UTC if local offset unavailable.
@@ -189,12 +190,109 @@ pub fn clean_dispatch_dirs(repo_root: &str) {
     }
 }
 
-/// Detect the machine's local network IP by connecting a UDP socket.
-/// No data is sent; this just determines the outgoing interface address.
+/// Detect the machine's local network IP.
+/// Prefers a physical LAN IPv4 over VPN or virtual adapters when possible.
 pub fn local_ip() -> Option<String> {
+    preferred_lan_ipv4()
+        .map(|ip| ip.to_string())
+        .or_else(route_local_ip)
+}
+
+/// Pick the best LAN IPv4 to show in the UI and advertise over mDNS.
+///
+/// We prefer RFC1918 addresses on physical Ethernet/Wi-Fi interfaces and
+/// penalize VPN and virtual adapters. This avoids resolving the console to
+/// WARP, Hyper-V, Docker, or other non-LAN interfaces on Windows machines.
+pub fn preferred_lan_ipv4() -> Option<Ipv4Addr> {
+    let mut candidates = get_if_addrs()
+        .ok()?
+        .into_iter()
+        .filter_map(|interface| match interface.addr {
+            IfAddr::V4(addr) => {
+                let score = score_ipv4_candidate(&interface.name, addr.ip)?;
+                Some((score, interface.name, addr.ip))
+            }
+            IfAddr::V6(_) => None,
+        })
+        .collect::<Vec<_>>();
+
+    candidates.sort_by(|a, b| a.cmp(b));
+    candidates.pop().map(|(_, _, ip)| ip)
+}
+
+fn route_local_ip() -> Option<String> {
     let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
     socket.connect("8.8.8.8:80").ok()?;
     socket.local_addr().ok().map(|a| a.ip().to_string())
+}
+
+fn score_ipv4_candidate(interface_name: &str, ip: Ipv4Addr) -> Option<i32> {
+    if ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_broadcast()
+        || ip.is_multicast()
+        || ip.is_unspecified()
+    {
+        return None;
+    }
+
+    let mut score = if ip.is_private() {
+        400
+    } else if is_cgnat(ip) {
+        -200
+    } else {
+        50
+    };
+
+    if looks_virtual_interface(interface_name) {
+        score -= 300;
+    } else if looks_physical_interface(interface_name) {
+        score += 100;
+    }
+
+    Some(score)
+}
+
+fn looks_physical_interface(interface_name: &str) -> bool {
+    let name = interface_name.to_ascii_lowercase();
+    name.contains("ethernet")
+        || name.contains("wi-fi")
+        || name.contains("wifi")
+        || name.starts_with("en")
+        || name.starts_with("eth")
+        || name.starts_with("wl")
+}
+
+fn looks_virtual_interface(interface_name: &str) -> bool {
+    let name = interface_name.to_ascii_lowercase();
+    [
+        "warp",
+        "cloudflare",
+        "vethernet",
+        "hyper-v",
+        "virtual",
+        "vmware",
+        "virtualbox",
+        "vbox",
+        "docker",
+        "podman",
+        "tailscale",
+        "zerotier",
+        "wireguard",
+        "loopback",
+        "bluetooth",
+        "bridge",
+        "hamachi",
+        "tun",
+        "tap",
+    ]
+    .iter()
+    .any(|keyword| name.contains(keyword))
+}
+
+fn is_cgnat(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    octets[0] == 100 && (64..=127).contains(&octets[1])
 }
 
 /// Compute PTY dimensions from terminal size.
@@ -313,5 +411,27 @@ mod tests {
     fn strip_action_blocks_preserves_ascii() {
         let plain = "The quick brown fox jumps over the lazy dog.";
         assert_eq!(strip_action_blocks(plain), plain);
+    }
+
+    #[test]
+    fn prefers_physical_private_ip_over_vpn_ip() {
+        let ethernet = score_ipv4_candidate("Ethernet 5", Ipv4Addr::new(10, 61, 5, 37)).unwrap();
+        let warp = score_ipv4_candidate("CloudflareWARP", Ipv4Addr::new(100, 96, 2, 212)).unwrap();
+        assert!(ethernet > warp);
+    }
+
+    #[test]
+    fn penalizes_virtual_private_interfaces() {
+        let ethernet = score_ipv4_candidate("Ethernet 5", Ipv4Addr::new(10, 61, 5, 37)).unwrap();
+        let hyper_v =
+            score_ipv4_candidate("vEthernet (Default Switch)", Ipv4Addr::new(172, 24, 160, 1))
+                .unwrap();
+        assert!(ethernet > hyper_v);
+    }
+
+    #[test]
+    fn rejects_loopback_and_link_local_ips() {
+        assert!(score_ipv4_candidate("Ethernet 5", Ipv4Addr::new(127, 0, 0, 1)).is_none());
+        assert!(score_ipv4_candidate("Ethernet 5", Ipv4Addr::new(169, 254, 1, 5)).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- pick a preferred LAN IPv4 instead of advertising every active interface
- prefer physical/private Ethernet or Wi-Fi addresses over VPN and virtual adapters
- use the same LAN IP for both mDNS advertisement and the connection info overlay

## Why
On machines with Cloudflare WARP, Hyper-V, Docker, or similar adapters, the console was advertising all interfaces via mDNS. Android discovery could then resolve the console to the wrong address, which breaks discovery/connectivity on the local network.

## Verification
- cargo test
- launched dispatch locally and confirmed startup now logs mdns: advertising _dispatch._tcp.local. on 10.61.5.37:9888 on this machine