### PR TITLE
Fix UI issues: ticker message and header init path

### DIFF
--- a/console/src/app.rs
+++ b/console/src/app.rs
@@ -187,6 +187,14 @@ impl App {
             .unwrap_or("claude")
     }
 
+    /// The root directory where dispatch was initialized.
+    pub fn init_path(&self) -> &str {
+        match &self.workspace {
+            Workspace::SingleRepo { root } => root.as_str(),
+            Workspace::MultiRepo { parent, .. } => parent.as_str(),
+        }
+    }
+
     /// Whether we're in multi-repo mode (dispatch-sa1).
     pub fn is_multi_repo(&self) -> bool {
         matches!(self.workspace, Workspace::MultiRepo { .. })
@@ -584,9 +592,15 @@ impl App {
             // Agents merge their own branches; this tool acknowledges the
             // completion and generates the system merge notification.
             tools::ToolCall::Merge { agent } => {
-                self.push_orch(OrchestratorEventKind::Merged { id: agent.clone() });
-                self.push_ticker(format!("MERGED: {}", agent));
-                self.push_chat("System", &format!("{} has merged to remote.", agent));
+                if self.merge_strategy == "pr" {
+                    self.push_orch(OrchestratorEventKind::PrCreated { id: agent.clone() });
+                    self.push_ticker(format!("PR CREATED: {}", agent));
+                    self.push_chat("System", &format!("{} has created a PR.", agent));
+                } else {
+                    self.push_orch(OrchestratorEventKind::Merged { id: agent.clone() });
+                    self.push_ticker(format!("MERGED: {}", agent));
+                    self.push_chat("System", &format!("{} has merged to remote.", agent));
+                }
 
                 tools::ToolResult::Merged {
                     agent: agent.clone(),

--- a/console/src/types.rs
+++ b/console/src/types.rs
@@ -45,6 +45,8 @@ pub enum OrchestratorEventKind {
     TaskComplete { id: String, agent: String },
     /// Worktree merged successfully.
     Merged { id: String },
+    /// Pull request created.
+    PrCreated { id: String },
     /// Merge conflict.
     MergeConflict { id: String },
     /// Agent dispatched into a slot.

--- a/console/src/ui.rs
+++ b/console/src/ui.rs
@@ -13,6 +13,26 @@ use ratatui::{
 use crate::types::*;
 use crate::util::{format_runtime, local_ip, repo_name_from_path, truncate};
 
+// ── Path shortening ───────────────────────────────────────────────────────
+
+/// Shorten a path for display. If within `max` chars, return as-is.
+/// Otherwise, show the last directory component (with ".../" prefix if truncated).
+fn shorten_path(path: &str, max: usize) -> String {
+    if path.chars().count() <= max {
+        return path.to_string();
+    }
+    let name = std::path::Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(path);
+    let prefixed = format!(".../{}", name);
+    if prefixed.chars().count() <= max {
+        prefixed
+    } else {
+        truncate(name, max)
+    }
+}
+
 // ── VT100 screen conversion ────────────────────────────────────────────────
 
 fn vt100_color_to_ratatui(color: vt100::Color) -> Option<Color> {
@@ -184,9 +204,11 @@ pub fn render_header(f: &mut Frame, area: Rect, app: &mut App) {
         Span::styled(right_padded, Style::default().fg(Color::White)),
     ]);
 
+    let init_dir = shorten_path(app.init_path(), 30);
+    let title = format!(" DISPATCH -- {} ", init_dir);
     let block = Block::default()
         .title(Span::styled(
-            " DISPATCH ",
+            title,
             Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
         ))
         .borders(Borders::ALL)
@@ -453,6 +475,11 @@ pub fn render_orchestrator(f: &mut Frame, area: Rect, app: &App) {
                 "MERGE",
                 Style::default().fg(Color::Green),
                 format!("{} merged to main", id),
+            ),
+            OrchestratorEventKind::PrCreated { id } => (
+                "PR",
+                Style::default().fg(Color::Green),
+                format!("{} created a PR", id),
             ),
             OrchestratorEventKind::MergeConflict { id } => (
                 "CONFLICT",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.4.5
+
+### Fixed
+
+- Ticker now shows "PR CREATED" instead of "MERGED" when merge_strategy is set to "pr". The orchestrator log event type also changes from "MERGE" to "PR" accordingly.
+
+### Added
+
+- The console header title now displays the initialization path (e.g. "DISPATCH -- myrepo"). Long paths are shortened to the last directory component.
+
 ## v0.4.4
 
 ### Changed

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -210,8 +210,8 @@ A single-line LED-style scrolling marquee between the header bar and the quad pa
 
 **Message sources:**
 
-- Agent events: `Alpha dispatched to myrepo`, `Bravo merged to main`
-- Merge results: `Alpha merged to main` or `Alpha merge conflict, needs manual review`
+- Agent events: `Alpha dispatched to myrepo`, `Bravo merged to main` (or `PR CREATED: Bravo` when merge_strategy is "pr")
+- Merge/PR results: `Alpha merged to main` or `PR CREATED: Alpha` (depends on merge_strategy) or `Alpha merge conflict, needs manual review`
 - Errors: `All agent slots full`
 
 **Rendering:** fixed-width viewport, text offset decremented each frame tick (e.g. every 50ms). Once a message scrolls fully off-screen, it is discarded and the next queued message begins. If multiple messages queue up during a burst, they scroll sequentially with a small gap between them.
@@ -220,7 +220,7 @@ A single-line LED-style scrolling marquee between the header bar and the quad pa
 
 The console displays agent state across multiple areas:
 
-- **Header bar**: active agent count, current page indicator, clock.
+- **Header bar**: initialization path, active agent count, current page indicator, clock.
 - **Ticker**: real-time event stream (dispatch, merges, errors).
 - **Pane info strip**: each pane shows its callsign, tool, and status.
 - **Orchestrator view** (`o` key): toggles the main area between the 2x2 agent grid and a scrollable orchestrator event log showing voice transcripts, reasoning decisions, and tool calls in real time.
@@ -230,7 +230,8 @@ The console displays agent state across multiple areas:
 Pressing `o` in command mode replaces the 2x2 agent grid with a full-height scrollable log of orchestrator events. Each entry is timestamped and categorized:
 
 - **MIC**: incoming voice transcripts from the radio.
-- **MERGE**: branch merged to main.
+- **MERGE**: branch merged to main (when merge_strategy is "merge").
+- **PR**: pull request created (when merge_strategy is "pr").
 - **CONFLICT**: merge conflict detected.
 - **DISPATCH**: agent launched into a slot.
 - **TERM**: agent terminated.
@@ -571,7 +572,7 @@ The console displays four agent panes at a time in a 2x2 grid. With more than fo
 Pages are cycled with `Left` / `Right` arrow keys. The header shows the current page and total pages.
 
 ```
-┌─ DISPATCH ──────────────────────────────────────────────────────────┐
+┌─ DISPATCH -- myrepo ────────────────────────────────────────────────┐
 │ RADIO: ● CONNECTED   PSK: a7f3...  PAGE 1/2                14:32    │
 │ ◄◄ Alpha dispatched to myrepo... Bravo merged to main               │
 ├────────────────────────────────┬────────────────────────────────────┤
@@ -607,7 +608,7 @@ Pages are cycled with `Left` / `Right` arrow keys. The header shows the current 
 Page 2 of the same session:
 
 ```
-┌─ DISPATCH ──────────────────────────────────────────────────────────┐
+┌─ DISPATCH -- myrepo ────────────────────────────────────────────────┐
 │ RADIO: ● CONNECTED   PSK: a7f3...  PAGE 2/2                14:32    │
 │ ◄◄ Echo merged to main                                              │
 ├────────────────────────────────┬────────────────────────────────────┤
@@ -645,7 +646,7 @@ Page 2 of the same session:
 **Input mode** changes the footer and the targeted pane's border:
 
 ```
-┌─ DISPATCH ──────────────────────────────────────────────────────────┐
+┌─ DISPATCH -- myrepo ────────────────────────────────────────────────┐
 │ RADIO: ● CONNECTED   PSK: a7f3...  PAGE 1/2                14:32    │
 │ ◄◄ Alpha merged to main                                             │
 ├────────────────────────────────┬────────────────────────────────────┤
@@ -670,7 +671,7 @@ Bright green border on the active pane. Footer shows mode indicator.
 
 **Regions:**
 
-1. **Header bar** -- radio connection state, PSK (truncated), current page indicator, clock.
+1. **Header bar** -- title with initialization path (shortened if too long), radio connection state, PSK (truncated), current page indicator, clock.
 2. **Ticker** -- single-line LED-style scrolling marquee. Shows agent events, merge results, and errors. Text scrolls right-to-left. Blank when idle. See [Ticker](#ticker).
 3. **Quad pane** -- four slots from the current page. Targeted pane has `▸` marker and cyan border (command mode) or green border (input mode). Each pane has:
    - **Info strip**: callsign, tool type, status (busy/idle), dispatch time, and runtime.


### PR DESCRIPTION
## Summary
- Ticker now shows "PR CREATED" instead of "MERGED" when merge_strategy is set to "pr". Chat messages and orchestrator log events also reflect this.
- Header title now displays the initialization path (e.g. "DISPATCH -- myrepo"). Long paths are shortened to the last directory component.

Closes #24

## Test plan
- [ ] Launch console with merge_strategy = "pr", dispatch an agent, verify ticker shows "PR CREATED: Agent"
- [ ] Launch console with merge_strategy = "merge", verify ticker still shows "MERGED: Agent"
- [ ] Verify header shows "DISPATCH -- dirname" with the correct repo/workspace name
- [ ] Test with a long path to verify shortening works correctly