### PR TITLE
Show working directory path in header top bar

### DIFF
--- a/console/src/app.rs
+++ b/console/src/app.rs
@@ -187,6 +187,14 @@ impl App {
             .unwrap_or("claude")
     }
 
+    /// The directory the console was launched in.
+    pub fn working_dir(&self) -> &str {
+        match &self.workspace {
+            Workspace::SingleRepo { root } => root.as_str(),
+            Workspace::MultiRepo { parent, .. } => parent.as_str(),
+        }
+    }
+
     /// Whether we're in multi-repo mode (dispatch-sa1).
     pub fn is_multi_repo(&self) -> bool {
         matches!(self.workspace, Workspace::MultiRepo { .. })

--- a/console/src/ui.rs
+++ b/console/src/ui.rs
@@ -11,7 +11,7 @@ use ratatui::{
 };
 
 use crate::types::*;
-use crate::util::{format_runtime, local_ip, repo_name_from_path, truncate};
+use crate::util::{format_runtime, local_ip, repo_name_from_path, truncate, truncate_left};
 
 // ── VT100 screen conversion ────────────────────────────────────────────────
 
@@ -184,11 +184,23 @@ pub fn render_header(f: &mut Frame, area: Rect, app: &mut App) {
         Span::styled(right_padded, Style::default().fg(Color::White)),
     ]);
 
+    // Right-aligned directory path in the top border.
+    let dir_label = {
+        let dir = app.working_dir();
+        // Leave room for " DISPATCH " title (10 chars) + borders (2) + padding (4).
+        let max_len = (area.width as usize).saturating_sub(16);
+        format!(" {} ", truncate_left(dir, max_len))
+    };
+
     let block = Block::default()
         .title(Span::styled(
             " DISPATCH ",
             Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
         ))
+        .title_top(Line::from(Span::styled(
+            dir_label,
+            Style::default().fg(Color::DarkGray),
+        )).right_aligned())
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Green));
 

--- a/console/src/util.rs
+++ b/console/src/util.rs
@@ -62,6 +62,22 @@ pub fn format_runtime(elapsed: Duration) -> String {
     format!("{}m{:02}s", s / 60, s % 60)
 }
 
+/// Truncate a string from the left to `max` chars, prepending "..." if trimmed.
+/// Useful for paths where the rightmost portion (directory name) is most important.
+pub fn truncate_left(s: &str, max: usize) -> String {
+    let char_count = s.chars().count();
+    if char_count <= max {
+        return s.to_string();
+    }
+    if max > 3 {
+        let skip = char_count - (max - 3);
+        let truncated: String = s.chars().skip(skip).collect();
+        format!("...{}", truncated)
+    } else {
+        s.chars().skip(char_count - max).collect()
+    }
+}
+
 /// Truncate a string to `max` chars, appending "..." if trimmed.
 /// Uses char count (not byte length) for the comparison and char
 /// boundaries for slicing to avoid panicking on multi-byte UTF-8.


### PR DESCRIPTION
## Summary
- Displays the working directory path on the right side of the DISPATCH header border
- Long paths are truncated from the left (e.g. `...GitHub/dispatch`) so the directory name stays visible
- Adds `truncate_left` utility and `working_dir()` accessor on App

## Test plan
- [ ] Launch console in a repo directory, verify the path appears right-aligned in the top bar border
- [ ] Launch from a deep path to verify left-truncation kicks in on narrow terminals
- [ ] Verify existing tests pass (`cargo test`)