### PR TITLE
Block orchestrator file tools via --disallowedTools

### DIFF
--- a/console/core/src/orchestrator.rs
+++ b/console/core/src/orchestrator.rs
@@ -158,6 +158,9 @@ fn spawn_stream_json(system_prompt: &str, cwd: &str, tool_cmd: &str, nonce: &str
         "--output-format", "stream-json",
         "--input-format", "stream-json",
         "--verbose",
+        // Block file/code tools so the orchestrator cannot investigate the
+        // codebase itself. It must delegate to agents via action blocks.
+        "--disallowedTools", "Read,Edit,Write,Bash,Glob,Grep,WebFetch,WebSearch,Agent,NotebookEdit",
     ]);
     cmd.args(["--system-prompt", system_prompt]);
     cmd.current_dir(cwd);

--- a/docs/ORCHESTRATOR.md
+++ b/docs/ORCHESTRATOR.md
@@ -6,11 +6,11 @@ You do not write code yourself. You coordinate agents that do the work.
 
 ## Ground Rules
 
-**Do NOT use Claude Code tools** (Read, Edit, Write, Bash, Glob, Grep, etc.). Do not read files, search code, or run commands yourself. Using tools blocks you from receiving messages, which defeats the purpose of being a coordinator. If you need something investigated, dispatch an agent.
+1. **Act ONLY through action blocks.** Write JSON commands inside ` ```action ` fences in your response text. The console parses your text and executes any action blocks it finds. Text without an action block does nothing -- if you say "Dispatching Alpha" without an action block, nothing happens. Every dispatch, message, merge, and strike team MUST include the action block.
 
-**Always act through action blocks.** Action blocks are how you control the system -- they are your primary output. Every dispatch, message, merge, and strike team launch MUST be an action block. Text alone does nothing.
+2. **Do NOT use Read, Edit, Write, Bash, Glob, Grep, or any other Claude Code tool.** They are blocked and will fail. You do not need them. If something needs investigating, dispatch an agent.
 
-**Strike team = one action block.** When Dispatch asks for a strike team, your entire response should be the `strike_team` action block and a brief confirmation. Do not read the document first -- a planner agent is dispatched automatically to handle that.
+3. **Strike team = immediate `strike_team` action block.** When Dispatch asks for a strike team on a document, respond with the `strike_team` action block and nothing else. Do not read the document. Do not create your own plan. A planner agent is dispatched automatically to analyze the document and break it into tasks.
 
 ## Message Format
 


### PR DESCRIPTION
## Summary
- Add `--disallowedTools` to orchestrator spawn blocking Read, Edit, Write, Bash, Glob, Grep, WebFetch, WebSearch, Agent, NotebookEdit
- Rewrite Ground Rules: action blocks are text output (not tool calls), strike team = immediate action block, tools are blocked and will fail

## Problem
The orchestrator was spending 4+ minutes using Claude Code's Read tool to read specs itself, creating manual "battle plans", and saying "Dispatching Alpha" without actually emitting action blocks. Prompt-only fixes were overridden by Claude Code's built-in tool behavior.