### PR TITLE
Use --tools empty to strip all Claude Code tools from orchestrator

### DIFF
--- a/console/core/src/orchestrator.rs
+++ b/console/core/src/orchestrator.rs
@@ -158,10 +158,11 @@ fn spawn_stream_json(system_prompt: &str, cwd: &str, tool_cmd: &str, nonce: &str
         "--output-format", "stream-json",
         "--input-format", "stream-json",
         "--verbose",
-        // Block file/code tools so the orchestrator cannot investigate the
-        // codebase itself. It must delegate to agents via action blocks.
-        "--disallowedTools", "Read,Edit,Write,Bash,Glob,Grep,WebFetch,WebSearch,Agent,NotebookEdit",
     ]);
+    // Remove all Claude Code built-in tools. The orchestrator acts purely
+    // through action blocks written in its text output, not tool calls.
+    cmd.arg("--tools");
+    cmd.arg("");
     cmd.args(["--system-prompt", system_prompt]);
     cmd.current_dir(cwd);
     cmd.stdin(Stdio::piped());

--- a/docs/ORCHESTRATOR.md
+++ b/docs/ORCHESTRATOR.md
@@ -6,11 +6,20 @@ You do not write code yourself. You coordinate agents that do the work.
 
 ## Ground Rules
 
-1. **Act ONLY through action blocks.** Write JSON commands inside ` ```action ` fences in your response text. The console parses your text and executes any action blocks it finds. Text without an action block does nothing -- if you say "Dispatching Alpha" without an action block, nothing happens. Every dispatch, message, merge, and strike team MUST include the action block.
+**You act by writing action blocks in your response text.** The console reads your text and executes any action blocks it finds. If your response has no action block, nothing happens. Saying "Dispatching Alpha" without an action block does nothing.
 
-2. **Do NOT use Read, Edit, Write, Bash, Glob, Grep, or any other Claude Code tool.** They are blocked and will fail. You do not need them. If something needs investigating, dispatch an agent.
+For example, to launch a strike team your COMPLETE response is:
 
-3. **Strike team = immediate `strike_team` action block.** When Dispatch asks for a strike team on a document, respond with the `strike_team` action block and nothing else. Do not read the document. Do not create your own plan. A planner agent is dispatched automatically to analyze the document and break it into tasks.
+````
+Mobilizing strike team.
+```action
+{"action": "strike_team", "source_file": "spec.md", "repo": "myrepo"}
+```
+````
+
+**Strike team requests:** when Dispatch asks for a strike team on a document, respond with the `strike_team` action block immediately. Do not read the document or create a plan -- a planner agent is dispatched automatically to handle that.
+
+**Do not read files or run commands.** You cannot. If something needs investigating, dispatch an agent via action block.
 
 ## Message Format
 


### PR DESCRIPTION
## Summary
- Replace `--disallowedTools` with `--tools ""` to remove tools from the model's context entirely (not just block them)
- Rewrite Ground Rules with concrete action block example showing the exact response format
- Model no longer sees any tools, so it can only generate text with action blocks

## Problem
`--disallowedTools` blocked tools but the model kept retrying Read 4+ times before giving up, wasting time and never falling back to action blocks.