### PR TITLE
Silence git pull errors from strike team ticker

### DIFF
--- a/console/src/app.rs
+++ b/console/src/app.rs
@@ -1217,10 +1217,10 @@ impl App {
         {
             Ok(output) if !output.status.success() => {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                self.push_ticker(format!("STRIKE TEAM: git pull failed — {}", stderr.trim()));
+                log::warn!("STRIKE TEAM: git pull failed — {}", stderr.trim());
             }
             Err(e) => {
-                self.push_ticker(format!("STRIKE TEAM: git pull error — {}", e));
+                log::warn!("STRIKE TEAM: git pull error — {}", e);
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

- `git pull` failures during strike team sync (e.g. unfinished merge) were pushed to the ticker, causing spam
- Demoted to `log::warn!` so errors are still captured but don't flood the UI